### PR TITLE
Fixed open modal task and list after edition, edit list and not add one

### DIFF
--- a/projects/task-manager/js/app.js
+++ b/projects/task-manager/js/app.js
@@ -191,13 +191,21 @@ function openModalList() {
  */
 function closeModalList() {
 	windowAddList.close();
+	idListEdit = null;
 }
 
 /**
  * Adds a list, closes the modal add list, update everything
  */
 function saveList() {
-	lists.push(new List({ title: titleList.value, color: colorList.value }));
+	const listExist = idListEdit ? lists.find(l => l.id === idListEdit) : false
+	if (!listExist) lists.push(new List({ title: titleList.value, color: colorList.value }));
+	else lists = lists.map(l => {
+		if (l.id !== idListEdit) return l;
+		l.title = titleList.value;
+		l.color = color: colorList.value;
+		return l;
+	});
 	closeModalList();
 	update();
 }
@@ -234,6 +242,7 @@ function openWindowTask(idList = null) {
 
 function closeModalTask() {
 	windowAddTask.close();
+	idTaskEdit = null;
 }
 
 function saveTask() {


### PR DESCRIPTION
Fixed a bug where after an edition of list and task, idListEdit and idTaskEdit ar not reset so it tries to get one but we are adding a task or list so it breaks.
When editing a list, it adds one and not update the editing one.